### PR TITLE
Added Browser Field to Package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Node Client for SoftAP Setup",
   "main": "index.js",
+  "browser": "./softap.js",
   "scripts": {
     "test": "mocha test/"
   },


### PR DESCRIPTION
This should direct Browserify to bundle the SoftAPSetup code using `softap.js` as an entry point instead of `index.js`.  `index.js` will cause non-recoverable crashes when browserified, because the `nconf` module is not Browserify-compatible.  **This makes the `softap-setup` node module compatible with Meteor via the [cosmos:browserify](https://atmospherejs.com/cosmos/browserify) package.**

Inside the node module's `package.json`, these parameters:

```
  "browser": "./softap.js"
```

do the same thing as @brewnerd's suggested browserify command,

``` js
  browserify softap.js -s SoftAPSetup -o softap-browser.js
```

Refer to the [Browserify docs](https://github.com/substack/node-browserify#browser-field) for more info.
