### PR TITLE
Adding content-type header to POST requests to avoid OPTIONS requests

### DIFF
--- a/softap.js
+++ b/softap.js
@@ -238,7 +238,15 @@ SoftAP.prototype.__httpRequest = function __httpRequest(cmd, data, error) {
 
 	if((cmd.body) && typeof cmd.body === 'object') {
 		payload = JSON.stringify(cmd.body);
-		opts.headers = { 'Content-Length': payload.length };
+		// NOTE: 'Content-Type' is set here to make this a "simple" cross-site
+		// request, as per the HTTP CORS docs:
+		//   https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Simple_requests
+		// According to the spec, this means that POST can be made directly
+		// without an OPTIONS request being made first.
+		opts.headers = {
+			'Content-Length': payload.length,
+			'Content-Type': 'application/x-www-form-urlencoded'
+		};
 		opts.method = 'POST';
 	}
 


### PR DESCRIPTION
This fix addresses the last remaining (client-side) issue after @m-mcgowan's work in https://github.com/spark/firmware/pull/694.

I've tested this out from the node cli on Yosemite and also when packaged up within [softap-setup-meteor](https://github.com/msolters/softap-setup-meteor) on Android and iOS both, and it seems to work in all cases. 
