### PR TITLE
Explicitly set protocol on requests for Android

### DIFF
--- a/softap.js
+++ b/softap.js
@@ -233,7 +233,8 @@ SoftAP.prototype.__httpRequest = function __httpRequest(cmd, data, error) {
 		method: 'GET',
 		path: '/' + cmd.name,
 		hostname: this.host,
-		port: this.port
+		port: this.port,
+		protocol: this.protocol ? this.protocol + ":" : ''
 	};
 
 	if((cmd.body) && typeof cmd.body === 'object') {


### PR DESCRIPTION
I'm using the latest Android with cordova webview.  The webview won't resolve relative urls.

I don't know why the `http.request` function doesn't append the colon after the protocol so I added it here.  Not sure if that's an oversight or by design.
