### PR TITLE
TCP SoftAP response received in multiple packets

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function SoftAPSetup(options) {
 	var opts = {
 		host: '192.168.0.1',
 		keepAlive: true,
-		timeout: 2000,
+		timeout: 8000,
 		noDelay: true,
 		channel: 6,
 		protocol: 'tcp'

--- a/lib/TcpSoftAP.js
+++ b/lib/TcpSoftAP.js
@@ -11,6 +11,7 @@ util.inherits(TcpSoftAP, SoftAP);
 
 TcpSoftAP.prototype._sendProtocolCommand = function _sendProtocolCommand(cmd, cb) {
 	var err, json;
+	var data = '';
 
 	var sock = net.createConnection(this.port, this.host);
 	sock.setNoDelay(this.noDelay);
@@ -35,19 +36,15 @@ TcpSoftAP.prototype._sendProtocolCommand = function _sendProtocolCommand(cmd, cb
 		sock.write(send);
 	});
 
-	sock.once('data', function socketData(dat) {
-		clearTimeout(to);
-		if (dat instanceof Buffer || typeof dat === 'string') {
-			try {
-				json = JSON.parse(dat.toString());
-			} catch (e) {
-				return cb(new Error('Invalid JSON received from device.'));
-			}
-		} else if (typeof dat === 'object') {
-			json = dat;
+	sock.on('data', function socketData(chunk) {
+		data += chunk.toString();
+		try {
+			json = JSON.parse(data);
+			clearTimeout(to);
+			sock.end();
+		} catch (e) {
+			// Wait for more data to come in
 		}
-
-		sock.end();
 	});
 
 	sock.once('error', function socketError(error) {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "istanbul": "^0.4.0",
     "mocha": "^2.2.4",
     "should": "^8.2.2",
-    "softap-emulator-js": "^1.0.1"
+    "softap-emulator-js": "^1.0.2"
   }
 }


### PR DESCRIPTION
While setting up a Photon at my office where there are 28 WiFi networks I ran into a bug in softap-setup where the JSON response is assumed to fit in one TCP packet.

I changed the algorithm to try JSON parsing with all the data received so far until it succeeds or there is a timeout.

I also had to bump up the default timeout since the scan takes longer than 2 seconds in my office. I didn't find a place in the `particle-cli` where the SoftAP scan timeout is increased so I bumped it up here.

I also removed the check for the object type in `sock.on('data')` since that's a relic of the multi-protocol `onData` function and not needed anymore for the TCP only version.

I realize @brycekahle that you're in the process of making a bunch of changes to this library and the CLI, and that using `softap-setup-js 4.0.1` in the current `particle-cli` doesn't work, but I worked around the integration issues in the CLI to make sure this change works.

Here's an example of the data I receive (captured by a couple `console.log` in `TcpSoftAP.js`):

```
▐ Asking the Photon to scan for nearby Wi-Fi networks...
Receiving data 

{"scans":[{"ssid":"HiveNet","rssi":-68,"sec":4194308,"ch":11,"mdr":216700},{"ssid":"cssw-private","rssi":-55,"sec":4194308,"ch":1,"mdr":144400},{"ssid":"csswjones","rssi":-62,"sec":1,"ch":2,"mdr":54000},{"ssid":"HP-Print-4F-Officejet 4630","rssi":-67,"sec":0,"ch":1,"mdr":54000},{"ssid":"TechBrewery","rssi":-73,"sec":4194308,"ch":1,"mdr":216700},{"ssid":"xfinitywifi","rssi":-81,"sec":0,"ch":1,"mdr":216700},{"ssid":"intergalactic","rssi":-82,"sec":4194308,"ch":1,"mdr":144400},{"ssid":"xfinitywifi","rssi":-79,"sec":0,"ch":11,"mdr":216700},{"ssid":"TechTavern","rssi":-76,"sec":4194308,"ch":11,"mdr":216700},{"ssid":"SBD-NA","rssi":-71,"sec":4194308,"ch":11,"mdr":144400},{"ssid":"avalonet2","rssi":-67,"sec":2097154,"ch":5,"mdr":54000},{"ssid":"A2JW2","rssi":-79,"sec":4194310,"ch":11,"mdr":216700},{"ssid":"zzzzzzz","rssi":-69,"sec":4194308,"ch":11,"mdr":216700},{"ssid":"avalonet2","rssi":-58,"sec":2097154,"ch":5,"mdr":54000},{"ssid":"DIRECT-7b-HP M477 LaserJet","rssi":-75,"sec":4194308,"ch":6,"mdr":72200},{"ssid":"CreativeTechnology","rssi":-70,"sec":4194310,"ch":6,"mdr":300000},{"ssid":"TechBreweryNew","rssi":-64,"sec":4194308,"ch":8,"mdr
Receiving data ":300000}]}
Socket close
Parsing JSON 

{"scans":[{"ssid":"HiveNet","rssi":-68,"sec":4194308,"ch":11,"mdr":216700},{"ssid":"cssw-private","rssi":-55,"sec":4194308,"ch":1,"mdr":144400},{"ssid":"csswjones","rssi":-62,"sec":1,"ch":2,"mdr":54000},{"ssid":"HP-Print-4F-Officejet 4630","rssi":-67,"sec":0,"ch":1,"mdr":54000},{"ssid":"TechBrewery","rssi":-73,"sec":4194308,"ch":1,"mdr":216700},{"ssid":"xfinitywifi","rssi":-81,"sec":0,"ch":1,"mdr":216700},{"ssid":"intergalactic","rssi":-82,"sec":4194308,"ch":1,"mdr":144400},{"ssid":"xfinitywifi","rssi":-79,"sec":0,"ch":11,"mdr":216700},{"ssid":"TechTavern","rssi":-76,"sec":4194308,"ch":11,"mdr":216700},{"ssid":"SBD-NA","rssi":-71,"sec":4194308,"ch":11,"mdr":144400},{"ssid":"avalonet2","rssi":-67,"sec":2097154,"ch":5,"mdr":54000},{"ssid":"A2JW2","rssi":-79,"sec":4194310,"ch":11,"mdr":216700},{"ssid":"zzzzzzz","rssi":-69,"sec":4194308,"ch":11,"mdr":216700},{"ssid":"avalonet2","rssi":-58,"sec":2097154,"ch":5,"mdr":54000},{"ssid":"DIRECT-7b-HP M477 LaserJet","rssi":-75,"sec":4194308,"ch":6,"mdr":72200},{"ssid":"CreativeTechnology","rssi":-70,"sec":4194310,"ch":6,"mdr":300000},{"ssid":"TechBreweryNew","rssi":-64,"sec":4194308,"ch":8,"mdr":300000}]}
```
