### PR TITLE
update browserify cmd to point to correct file

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Valid security types are as follows:
 
 ### AP Password Security
 
-It's worth noting that this library uses the public key of the device to encrypt any AP passwords that are sent when configuring and connecting your device. 
+It's worth noting that this library uses the public key of the device to encrypt any AP passwords that are sent when configuring and connecting your device.
 
 ## Running in the Browser
 
@@ -175,7 +175,7 @@ npm install -g browserify
 ```
 From the softap-setup-js code directory, run:
 ```js
-browserify softap.js -s SoftAPSetup -o softap-browser.js
+browserify index.js -s SoftAPSetup -o softap-browser.js
 ```
 This will create a browser-friendly ```softap-browser.js``` file that exports the ```SoftAPSetup``` object. The only difference with the browser version of this object is that it does *NOT* support reading the configuration from a file. All other methods described above will work.
 
@@ -188,7 +188,7 @@ This will create a browser-friendly ```softap-browser.js``` file that exports th
 <head></head>
 <body>
   <script src="softap-browser.js"></script>
-  <script> 
+  <script>
     var sap = new SoftAPSetup();
 
     sap.deviceInfo(callback);


### PR DESCRIPTION
This just changes the instructions for running the module through `browserify` for usage in the browser. The previous README passed `softap.js`, but the module's entry point is now `index.js`.
