### PR TITLE
Fix license key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       "email": "rawlatv@gmail.com"
     }
   ],
-  "license": "LGPL-3.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/spark/softap-setup-js/issues"
   },


### PR DESCRIPTION
The license for this package was changed to Apache 2.0 in https://github.com/particle-iot/softap-setup-js/pull/17 but the package.json was not updated.